### PR TITLE
Release/v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 4.2.0
+### Dependencies
+- Upgrade adrastia-core to v4.2.0.
+
+### Accumulators
+- Ensure heartbeat is not zero in setConfig
+- Revert if the config is unchanged in setConfig
+
+### Oracles
+- Revert if the pause status is unchanged in setUpdatesPaused
+- Revert if the token config is unchanged in setTokenConfig
+- Revert if the config is unchanged in setConfig
+
+### Prudentia
+#### Controllers
+- Revert if a component has zero weight in setConfig
+- Revert if duplicate components are provided in setConfig
+- Revert if the pause status is unchanged in setUpdatesPaused
+- Fix precision loss error in computeRateInternal
+
 ## v4.1.0
 ### Accumulators
 - Add ManagedCometSBAccumulator and ManagedAaveV3SBAccumulator

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adrastia Periphery
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![3327 out of 3327 tests passing](https://img.shields.io/badge/tests-3327/3327%20passing-brightgreen.svg?style=flat-square)
+![3398 out of 3398 tests passing](https://img.shields.io/badge/tests-3327/3327%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Adrastia Periphery is a set of Solidity smart contracts that complement the [Adrastia Core](https://github.com/adrastia-oracle/adrastia-core) smart contracts.

--- a/contracts/accumulators/AccumulatorConfig.sol
+++ b/contracts/accumulators/AccumulatorConfig.sol
@@ -23,6 +23,12 @@ abstract contract AccumulatorConfig is AccessControlEnumerable {
     /// @dev An error thrown when attempting to set an invalid configuration.
     error InvalidConfig(Config config);
 
+    /// @notice An error thrown when attempting to set a new configuration that is the same as the current
+    /// configuration.
+    /// @dev This is thrown to make it more noticeable when nothing changes. It's probably a mistake.
+    /// @param config The unchanged configuration.
+    error ConfigUnchanged(Config config);
+
     /// @notice An error thrown when attempting to call a function that requires a certain role.
     /// @param account The account that is missing the role.
     /// @param role The role that is missing.
@@ -65,6 +71,16 @@ abstract contract AccumulatorConfig is AccessControlEnumerable {
         if (newConfig.heartbeat == 0) revert InvalidConfig(newConfig);
 
         Config memory oldConfig = config;
+
+        // Ensure that the new config is different from the current config
+        if (
+            oldConfig.updateThreshold == newConfig.updateThreshold &&
+            oldConfig.updateDelay == newConfig.updateDelay &&
+            oldConfig.heartbeat == newConfig.heartbeat
+        ) {
+            revert ConfigUnchanged(newConfig);
+        }
+
         config = newConfig;
         emit ConfigUpdated(oldConfig, newConfig);
     }

--- a/contracts/accumulators/AccumulatorConfig.sol
+++ b/contracts/accumulators/AccumulatorConfig.sol
@@ -59,9 +59,10 @@ abstract contract AccumulatorConfig is AccessControlEnumerable {
     function setConfig(Config calldata newConfig) external virtual onlyRole(Roles.CONFIG_ADMIN) {
         // Ensure that updateDelay is not greater than heartbeat
         if (newConfig.updateDelay > newConfig.heartbeat) revert InvalidConfig(newConfig);
-
         // Ensure that updateThreshold is not zero
         if (newConfig.updateThreshold == 0) revert InvalidConfig(newConfig);
+        // Ensure that the heartbeat is not zero
+        if (newConfig.heartbeat == 0) revert InvalidConfig(newConfig);
 
         Config memory oldConfig = config;
         config = newConfig;

--- a/contracts/oracles/ManagedCurrentAggregatorOracle.sol
+++ b/contracts/oracles/ManagedCurrentAggregatorOracle.sol
@@ -19,15 +19,20 @@ contract ManagedCurrentAggregatorOracle is CurrentAggregatorOracle, ManagedCurre
     function setUpdatesPaused(address token, bool paused) external virtual onlyRole(Roles.UPDATE_PAUSE_ADMIN) {
         uint16 flags = observationBufferMetadata[token].flags;
 
-        if (paused) {
-            flags |= PAUSE_FLAG_MASK;
+        bool currentlyPaused = (flags & PAUSE_FLAG_MASK) != 0;
+        if (currentlyPaused != paused) {
+            if (paused) {
+                flags |= PAUSE_FLAG_MASK;
+            } else {
+                flags &= ~PAUSE_FLAG_MASK;
+            }
+
+            observationBufferMetadata[token].flags = flags;
+
+            emit PauseStatusChanged(token, paused);
         } else {
-            flags &= ~PAUSE_FLAG_MASK;
+            revert PauseStatusUnchanged(token, paused);
         }
-
-        observationBufferMetadata[token].flags = flags;
-
-        emit PauseStatusChanged(token, paused);
     }
 
     function areUpdatesPaused(address token) external view virtual returns (bool) {

--- a/contracts/oracles/ManagedMedianFilteringOracle.sol
+++ b/contracts/oracles/ManagedMedianFilteringOracle.sol
@@ -19,15 +19,20 @@ contract ManagedMedianFilteringOracle is MedianFilteringOracle, ManagedHistorica
     function setUpdatesPaused(address token, bool paused) external virtual onlyRole(Roles.UPDATE_PAUSE_ADMIN) {
         uint16 flags = observationBufferMetadata[token].flags;
 
-        if (paused) {
-            flags |= PAUSE_FLAG_MASK;
+        bool currentlyPaused = (flags & PAUSE_FLAG_MASK) != 0;
+        if (currentlyPaused != paused) {
+            if (paused) {
+                flags |= PAUSE_FLAG_MASK;
+            } else {
+                flags &= ~PAUSE_FLAG_MASK;
+            }
+
+            observationBufferMetadata[token].flags = flags;
+
+            emit PauseStatusChanged(token, paused);
         } else {
-            flags &= ~PAUSE_FLAG_MASK;
+            revert PauseStatusUnchanged(token, paused);
         }
-
-        observationBufferMetadata[token].flags = flags;
-
-        emit PauseStatusChanged(token, paused);
     }
 
     function areUpdatesPaused(address token) external view virtual returns (bool) {

--- a/contracts/oracles/ManagedPeriodicAggregatorOracle.sol
+++ b/contracts/oracles/ManagedPeriodicAggregatorOracle.sol
@@ -15,15 +15,20 @@ contract ManagedPeriodicAggregatorOracle is PeriodicAggregatorOracle, ManagedAgg
     function setUpdatesPaused(address token, bool paused) external virtual onlyRole(Roles.UPDATE_PAUSE_ADMIN) {
         uint16 flags = observationBufferMetadata[token].flags;
 
-        if (paused) {
-            flags |= PAUSE_FLAG_MASK;
+        bool currentlyPaused = (flags & PAUSE_FLAG_MASK) != 0;
+        if (currentlyPaused != paused) {
+            if (paused) {
+                flags |= PAUSE_FLAG_MASK;
+            } else {
+                flags &= ~PAUSE_FLAG_MASK;
+            }
+
+            observationBufferMetadata[token].flags = flags;
+
+            emit PauseStatusChanged(token, paused);
         } else {
-            flags &= ~PAUSE_FLAG_MASK;
+            revert PauseStatusUnchanged(token, paused);
         }
-
-        observationBufferMetadata[token].flags = flags;
-
-        emit PauseStatusChanged(token, paused);
     }
 
     function areUpdatesPaused(address token) external view virtual returns (bool) {

--- a/contracts/oracles/ManagedPriceVolatilityOracle.sol
+++ b/contracts/oracles/ManagedPriceVolatilityOracle.sol
@@ -21,15 +21,20 @@ contract ManagedPriceVolatilityOracle is PriceVolatilityOracle, ManagedHistorica
     function setUpdatesPaused(address token, bool paused) external virtual onlyRole(Roles.UPDATE_PAUSE_ADMIN) {
         uint16 flags = observationBufferMetadata[token].flags;
 
-        if (paused) {
-            flags |= PAUSE_FLAG_MASK;
+        bool currentlyPaused = (flags & PAUSE_FLAG_MASK) != 0;
+        if (currentlyPaused != paused) {
+            if (paused) {
+                flags |= PAUSE_FLAG_MASK;
+            } else {
+                flags &= ~PAUSE_FLAG_MASK;
+            }
+
+            observationBufferMetadata[token].flags = flags;
+
+            emit PauseStatusChanged(token, paused);
         } else {
-            flags &= ~PAUSE_FLAG_MASK;
+            revert PauseStatusUnchanged(token, paused);
         }
-
-        observationBufferMetadata[token].flags = flags;
-
-        emit PauseStatusChanged(token, paused);
     }
 
     function areUpdatesPaused(address token) external view virtual returns (bool) {

--- a/contracts/oracles/bases/ManagedAggregatorOracleBase.sol
+++ b/contracts/oracles/bases/ManagedAggregatorOracleBase.sol
@@ -31,6 +31,13 @@ abstract contract ManagedAggregatorOracleBase is ManagedOracleBase {
 
     error InvalidTokenConfig(IOracleAggregatorTokenConfig config, uint256 errorCode);
 
+    /// @notice An error thrown when attempting to set a new token configuration that is the same as the current
+    /// configuration (using a only shallow check to allow for implementation changes).
+    /// @dev This is thrown to make it more noticeable when nothing changes. It's probably a mistake.
+    /// @param token The token whose configuration was unchanged.
+    /// @param config The unchanged configuration.
+    error TokenConfigUnchanged(address token, IOracleAggregatorTokenConfig config);
+
     /// @notice Constructs a new ManagedAggregatorOracleBase.
     constructor() ManagedOracleBase() {}
 
@@ -81,6 +88,10 @@ abstract contract ManagedAggregatorOracleBase is ManagedOracleBase {
         }
 
         IOracleAggregatorTokenConfig oldConfig = tokenConfigs[token];
+
+        // Ensure that the new config is different from the current config
+        if (oldConfig == newConfig) revert TokenConfigUnchanged(token, newConfig);
+
         tokenConfigs[token] = newConfig;
         emit TokenConfigUpdated(token, oldConfig, newConfig);
     }

--- a/contracts/oracles/bases/ManagedCurrentAggregatorOracleBase.sol
+++ b/contracts/oracles/bases/ManagedCurrentAggregatorOracleBase.sol
@@ -27,6 +27,12 @@ abstract contract ManagedCurrentAggregatorOracleBase is ManagedAggregatorOracleB
     /// @param errorCode The error code.
     error InvalidConfig(Config config, uint256 errorCode);
 
+    /// @notice An error thrown when attempting to set a new configuration that is the same as the current
+    /// configuration.
+    /// @dev This is thrown to make it more noticeable when nothing changes. It's probably a mistake.
+    /// @param config The unchanged configuration.
+    error ConfigUnchanged(Config config);
+
     /// @notice The current configuration for the update threshold, update delay, and heartbeat.
     Config internal config;
 
@@ -55,6 +61,16 @@ abstract contract ManagedCurrentAggregatorOracleBase is ManagedAggregatorOracleB
         if (newConfig.heartbeat == 0) revert InvalidConfig(newConfig, ERROR_HEARTBEAT_ZERO);
 
         Config memory oldConfig = config;
+
+        // Ensure that the new config is different from the current config
+        if (
+            oldConfig.updateThreshold == newConfig.updateThreshold &&
+            oldConfig.updateDelay == newConfig.updateDelay &&
+            oldConfig.heartbeat == newConfig.heartbeat
+        ) {
+            revert ConfigUnchanged(newConfig);
+        }
+
         config = newConfig;
         emit ConfigUpdated(oldConfig, newConfig);
     }

--- a/contracts/oracles/bases/ManagedHistoricalAggregatorOracleBase.sol
+++ b/contracts/oracles/bases/ManagedHistoricalAggregatorOracleBase.sol
@@ -32,6 +32,12 @@ abstract contract ManagedHistoricalAggregatorOracleBase is ManagedOracleBase {
     /// @param errorCode The error code.
     error InvalidConfig(Config config, uint256 errorCode);
 
+    /// @notice An error thrown when attempting to set a new configuration that is the same as the current
+    /// configuration.
+    /// @dev This is thrown to make it more noticeable when nothing changes. It's probably a mistake.
+    /// @param config The unchanged configuration.
+    error ConfigUnchanged(Config config);
+
     /// @notice The current configuration for the source, observation amount, observation offset, and observation
     /// increment.
     Config internal config;
@@ -71,6 +77,16 @@ abstract contract ManagedHistoricalAggregatorOracleBase is ManagedOracleBase {
         ) revert InvalidConfig(newConfig, ERROR_INVALID_SOURCE_DECIMAL_MISMATCH);
 
         Config memory oldConfig = config;
+
+        if (
+            oldConfig.source == newConfig.source &&
+            oldConfig.observationAmount == newConfig.observationAmount &&
+            oldConfig.observationOffset == newConfig.observationOffset &&
+            oldConfig.observationIncrement == newConfig.observationIncrement
+        ) {
+            revert ConfigUnchanged(newConfig);
+        }
+
         config = newConfig;
         emit ConfigUpdated(oldConfig, newConfig);
     }

--- a/contracts/oracles/bases/ManagedOracleBase.sol
+++ b/contracts/oracles/bases/ManagedOracleBase.sol
@@ -12,6 +12,14 @@ abstract contract ManagedOracleBase is AccessControlEnumerable {
     /// @param areUpdatesPaused Whether updates are paused for the token.
     event PauseStatusChanged(address indexed token, bool areUpdatesPaused);
 
+    /// @notice An error that is thrown when we try to change the pause state for a token, but the current pause state
+    /// is the same as the new pause state.
+    /// @dev This error is thrown to make it easier to notice when we try to change the pause state but nothing changes.
+    /// This is useful in preventing human error, in the case that we expect a change when there is none.
+    /// @param token The token for which we tried to change the pause state.
+    /// @param paused The pause state we tried to set.
+    error PauseStatusUnchanged(address token, bool paused);
+
     /// @notice An error that is thrown when updates are paused for a token.
     /// @param token The token for which updates are paused.
     error UpdatesArePaused(address token);

--- a/contracts/rates/RateController.sol
+++ b/contracts/rates/RateController.sol
@@ -129,6 +129,14 @@ abstract contract RateController is ERC165, HistoricalRates, IRateComputer, IUpd
                 revert InvalidConfig(token);
             }
 
+            // Check for duplicate components
+            for (uint256 j = i + 1; j < config.componentWeights.length; ++j) {
+                if (config.components[i] == config.components[j]) {
+                    // The same component cannot be used more than once.
+                    revert InvalidConfig(token);
+                }
+            }
+
             sum += config.componentWeights[i];
         }
         if (sum > 10000) {

--- a/contracts/rates/RateController.sol
+++ b/contracts/rates/RateController.sol
@@ -14,7 +14,7 @@ import "./IRateComputer.sol";
 /// @title RateController
 /// @notice A contract that periodically computes and stores rates for tokens.
 /// @dev This contract is abstract because it lacks restrictions on sensitive functions. Please override checkSetConfig,
-/// checkSetUpdatesPaused, checkSetRatesCapacity, and checkUpdate to add restrictions.
+/// checkManuallyPushRate, checkSetUpdatesPaused, checkSetRatesCapacity, and checkUpdate to add restrictions.
 abstract contract RateController is ERC165, HistoricalRates, IRateComputer, IUpdateable, IPeriodic {
     using SafeCast for uint256;
 

--- a/contracts/rates/RateController.sol
+++ b/contracts/rates/RateController.sol
@@ -369,16 +369,13 @@ abstract contract RateController is ERC165, HistoricalRates, IRateComputer, IUpd
     function computeRateInternal(address token) internal view virtual returns (uint64) {
         RateConfig memory config = rateConfigs[token];
 
-        uint64 rate = config.base;
+        uint256 componentRateNumerator;
 
         for (uint256 i = 0; i < config.componentWeights.length; ++i) {
-            uint64 componentRate = ((uint256(config.components[i].computeRate(token)) * config.componentWeights[i]) /
-                10000).toUint64();
-
-            rate += componentRate;
+            componentRateNumerator += uint256(config.components[i].computeRate(token)) * config.componentWeights[i];
         }
 
-        return rate;
+        return (config.base + (componentRateNumerator / 10000)).toUint64();
     }
 
     /// @notice Computes the target rate and clamps it based on the specified token's rate configuration.

--- a/contracts/rates/RateController.sol
+++ b/contracts/rates/RateController.sol
@@ -119,9 +119,7 @@ abstract contract RateController is ERC165, HistoricalRates, IRateComputer, IUpd
         }
 
         // Ensure that the sum of the component weights less than or equal to 10000 (100%)
-        // Notice: It's possible to have the sum of the component weights be less than 10000 (100%). It's also possible
-        // to have the component weights be 100% and the base rate be non-zero. This is intentional because we don't
-        // have a hard cap on the rate.
+        // Notice: It's possible to have the sum of the component weights be less than 10000 (100%).
         uint256 sum = 0;
         for (uint256 i = 0; i < config.componentWeights.length; ++i) {
             if (

--- a/contracts/rates/RateController.sol
+++ b/contracts/rates/RateController.sol
@@ -73,6 +73,14 @@ abstract contract RateController is ERC165, HistoricalRates, IRateComputer, IUpd
     /// @param updater The address of the rate updater.
     error UpdaterMustBeEoa(address txOrigin, address updater);
 
+    /// @notice An error that is thrown when we try to change the pause state for a token, but the current pause state
+    /// is the same as the new pause state.
+    /// @dev This error is thrown to make it easier to notice when we try to change the pause state but nothing changes.
+    /// This is useful in preventing human error, in the case that we expect a change when there is none.
+    /// @param token The token for which we tried to change the pause state.
+    /// @param paused The pause state we tried to set.
+    error PauseStatusUnchanged(address token, bool paused);
+
     /// @notice Creates a new rate controller.
     /// @param period_ The period of the rate controller, in seconds. This is the frequency at which rates are updated.
     /// @param initialBufferCardinality_ The initial capacity of the rate buffer.
@@ -238,6 +246,8 @@ abstract contract RateController is ERC165, HistoricalRates, IRateComputer, IUpd
             emit PauseStatusChanged(token, paused);
 
             onPaused(token, paused);
+        } else {
+            revert PauseStatusUnchanged(token, paused);
         }
     }
 

--- a/contracts/rates/RateController.sol
+++ b/contracts/rates/RateController.sol
@@ -129,6 +129,12 @@ abstract contract RateController is ERC165, HistoricalRates, IRateComputer, IUpd
                 revert InvalidConfig(token);
             }
 
+            if (config.componentWeights[i] == 0) {
+                // The component weight cannot be zero. Such a scenario would be a waste of gas and likely to be a
+                // human error in setting the config.
+                revert InvalidConfig(token);
+            }
+
             // Check for duplicate components
             for (uint256 j = i + 1; j < config.componentWeights.length; ++j) {
                 if (config.components[i] == config.components[j]) {

--- a/contracts/test/aave/MockAaveV3ConfigEngine.sol
+++ b/contracts/test/aave/MockAaveV3ConfigEngine.sol
@@ -3,11 +3,15 @@ pragma solidity =0.8.13;
 
 import "../../vendor/aave/IACLManager.sol";
 import "../../vendor/aave/IAaveV3ConfigEngine.sol";
+import "../../vendor/aave/AaveV3EngineFlags.sol";
 
 contract MockAaveV3ConfigEngine is IAaveV3ConfigEngine {
     IACLManager public aclManager;
 
     CapsUpdate public lastUpdate;
+
+    mapping(address => uint256) public supplyCap;
+    mapping(address => uint256) public borrowCap;
 
     event CapsUpdated(address asset, uint256 supplyCap, uint256 borrowCap);
 
@@ -15,12 +19,19 @@ contract MockAaveV3ConfigEngine is IAaveV3ConfigEngine {
         aclManager = aclManager_;
     }
 
-    function updateCaps(CapsUpdate[] memory _updates) external override {
+    function updateCaps(CapsUpdate[] calldata _updates) external override {
         require(aclManager.isRiskAdmin(msg.sender), "Only risk admin can call");
 
         require(_updates.length == 1, "Only one update allowed");
 
         lastUpdate = _updates[0];
+
+        if (_updates[0].supplyCap != EngineFlags.KEEP_CURRENT) {
+            supplyCap[_updates[0].asset] = _updates[0].supplyCap;
+        }
+        if (_updates[0].borrowCap != EngineFlags.KEEP_CURRENT) {
+            borrowCap[_updates[0].asset] = _updates[0].borrowCap;
+        }
 
         emit CapsUpdated(_updates[0].asset, _updates[0].supplyCap, _updates[0].borrowCap);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrastia-oracle/adrastia-periphery",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adrastia-oracle/adrastia-core": "4.1.0",
+    "@adrastia-oracle/adrastia-core": "4.2.0",
     "@openzeppelin-v3/contracts": "npm:@openzeppelin/contracts@3.4.2",
     "@openzeppelin-v4/contracts": "npm:@openzeppelin/contracts@4.6.0"
   },

--- a/scripts/mock/aave/verify/v3-config-engine.js
+++ b/scripts/mock/aave/verify/v3-config-engine.js
@@ -1,6 +1,6 @@
 const hre = require("hardhat");
 
-const contractAddress = "0x514eD25bBbf51811eBDFa42b150c4d6f0e2255B3";
+const contractAddress = "0x7Edc9806dB4Cda54681cFe09D31d12341eafb675";
 
 const aclManager = "0x5f77FceAB2fdf1839f00453Ede3E884810F51146";
 

--- a/scripts/rates/aave/deploy-oracle-mutation-computer.js
+++ b/scripts/rates/aave/deploy-oracle-mutation-computer.js
@@ -1,0 +1,52 @@
+const hre = require("hardhat");
+
+const ethers = hre.ethers;
+
+// Supply cap computer: 0x6853Db03894c5197671111cc7D86f2280e7fcC8e
+// Borrow cap computer: 0x2d4506A825D031Af598463A67Da11BeC700b753a
+
+// The oracle's data slot
+const DATA_SLOT_PRICE = 1;
+const DATA_SLOT_LIQUIDITY_TOKEN = 2;
+const DATA_SLOT_LIQUIDITY_QUOTETOKEN = 3;
+
+// Supply & Borrow oracle data slots
+const SUPPLY = DATA_SLOT_LIQUIDITY_QUOTETOKEN;
+const BORROW = DATA_SLOT_LIQUIDITY_TOKEN;
+
+async function main() {
+    // START OF USER CONFIGURATION
+
+    // Replace this address with the address of the Aave ACL Manager on your desired network
+    const aclManager = "0x5f77FceAB2fdf1839f00453Ede3E884810F51146"; // MockAaveACLManager on Polygon
+    // Replace this address with the address of the Adrastia oracle contract on your desired network
+    const oracle = "0xc0514a2A4eD8bA8cf3f9Bb71cC8d6e0cA0E5A4a7"; // Aave v3 S&B oracle on Polygon: v4.1.0
+    // Replace this with the data slot of the oracle to use
+    const dataSlot = SUPPLY;
+    // 1x scalar
+    const oneXScalar = ethers.BigNumber.from(10).pow(6);
+
+    // END OF USER CONFIGURATION
+
+    const [deployer] = await hre.ethers.getSigners();
+
+    const contractName = "AaveOracleMutationComputer";
+
+    console.log("Deploying " + contractName + " with account:", deployer.address);
+
+    const computerFactory = await hre.ethers.getContractFactory(contractName);
+    const computer = await computerFactory.deploy(aclManager, oracle, dataSlot, oneXScalar, 0);
+
+    await computer.deployed();
+
+    console.log(contractName + " deployed to:", computer.address);
+
+    console.log("Done");
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/scripts/rates/aave/deploy-v3-cap-controller.js
+++ b/scripts/rates/aave/deploy-v3-cap-controller.js
@@ -2,12 +2,12 @@ const hre = require("hardhat");
 
 const ethers = hre.ethers;
 
-// Supply cap controller: 0x76cD9e71cdbDbd96A9D34cAa20790e06dDE8a170
-// Borrow cap controller: 0xd0F50989e14f022E24398eE13b1833373D452629
+// Supply cap controller: 0xcD9B8Db8c0B097B043e8439684e0F3fB65b8b887
+// Borrow cap controller: 0x8B2B7321FC5C5EA2d185c6fb2Bf526c043166891
 
 async function main() {
-    const configEngine = "0x514eD25bBbf51811eBDFa42b150c4d6f0e2255B3";
-    const forSupplyCaps = false;
+    const configEngine = "0x7Edc9806dB4Cda54681cFe09D31d12341eafb675";
+    const forSupplyCaps = true;
     const aclManager = "0x5f77FceAB2fdf1839f00453Ede3E884810F51146";
     const period = 24 * 60 * 60; // 24 hours
     const initialBufferCardinality = 1;

--- a/scripts/rates/aave/verify/oracle-mutation-computer.js
+++ b/scripts/rates/aave/verify/oracle-mutation-computer.js
@@ -1,0 +1,38 @@
+const hre = require("hardhat");
+
+// The oracle's data slot
+const DATA_SLOT_PRICE = 1;
+const DATA_SLOT_LIQUIDITY_TOKEN = 2;
+const DATA_SLOT_LIQUIDITY_QUOTETOKEN = 3;
+
+// Supply & Borrow oracle data slots
+const SUPPLY = DATA_SLOT_LIQUIDITY_QUOTETOKEN;
+const BORROW = DATA_SLOT_LIQUIDITY_TOKEN;
+
+const contractAddress = "0x2d4506A825D031Af598463A67Da11BeC700b753a";
+
+// Replace this address with the address of the Aave ACL Manager on your desired network
+const aclManager = "0x5f77FceAB2fdf1839f00453Ede3E884810F51146"; // MockAaveACLManager on Polygon
+// Replace this address with the address of the Adrastia oracle contract on your desired network
+const oracle = "0xc0514a2A4eD8bA8cf3f9Bb71cC8d6e0cA0E5A4a7"; // Aave v3 S&B oracle on Polygon: v4.1.0
+// Replace this with the data slot of the oracle to use
+const dataSlot = BORROW;
+// 1x scalar
+const oneXScalar = ethers.BigNumber.from(10).pow(6);
+
+async function main() {
+    const contractName = "AaveOracleMutationComputer";
+
+    await hre.run("verify:verify", {
+        contract: "contracts/rates/computers/proto/aave/" + contractName + ".sol:" + contractName,
+        address: contractAddress,
+        constructorArguments: [aclManager, oracle, dataSlot, oneXScalar, 0],
+    });
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/scripts/rates/aave/verify/v3-cap-controller.js
+++ b/scripts/rates/aave/verify/v3-cap-controller.js
@@ -1,8 +1,8 @@
 const hre = require("hardhat");
 
-const contractAddress = "0xd0F50989e14f022E24398eE13b1833373D452629";
+const contractAddress = "0x8B2B7321FC5C5EA2d185c6fb2Bf526c043166891";
 
-const configEngine = "0x514eD25bBbf51811eBDFa42b150c4d6f0e2255B3";
+const configEngine = "0x7Edc9806dB4Cda54681cFe09D31d12341eafb675";
 const forSupplyCaps = false;
 const aclManager = "0x5f77FceAB2fdf1839f00453Ede3E884810F51146";
 const period = 24 * 60 * 60; // 24 hours

--- a/scripts/rates/print-mutated-value-computer-config.js
+++ b/scripts/rates/print-mutated-value-computer-config.js
@@ -4,7 +4,7 @@ const hre = require("hardhat");
 const ethers = hre.ethers;
 
 async function main() {
-    const token = "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"; // WETH on Polygon
+    const token = "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"; // WMATIC on Polygon
 
     // Default 1x scalar. Make sure to verify that the computer uses the same 1x scaler.
     const oneXScalar = ethers.BigNumber.from(10).pow(6);
@@ -16,7 +16,7 @@ async function main() {
     // The minimum value that will be returned by the computer (up to 2^64-1)
     const min = ethers.BigNumber.from(0);
     // The value to add after the value has been scaled by the scalar below
-    const offset = ethers.BigNumber.from(100);
+    const offset = ethers.BigNumber.from(100_000);
     // The scalar to multiply the value by before adding the offset
     const scalar = oneXScalar.add(oneXScalar.div(5)); // 1.2x
 

--- a/scripts/rates/print-rate-controller-config-amounts.js
+++ b/scripts/rates/print-rate-controller-config-amounts.js
@@ -3,29 +3,36 @@ const hre = require("hardhat");
 
 const ethers = hre.ethers;
 
+const POLYGON_USDC = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+const POLYGON_WBTC = "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6";
+const POLYGON_WMATIC = "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270";
+
+const POLYGON_AAVE_V3_SUPPLY_CAP_COMPUTER = "0x6853Db03894c5197671111cc7D86f2280e7fcC8e";
+const POLYGON_AAVE_V3_BORROW_CAP_COMPUTER = "0x2d4506A825D031Af598463A67Da11BeC700b753a";
+
 async function main() {
-    const token = "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"; // WETH on Polygon
+    const token = POLYGON_WBTC; // USDC on Polygon
 
     // The following configuration assumes all amounts are whole token amounts (no decimals)
 
     // The maximum rate
-    const max = ethers.utils.parseUnits("1", 9); // 1,000,000,000 WETH
+    const max = ethers.utils.parseUnits("1", 9); // 1,000,000,000
     // The minimum rate
-    const min = ethers.utils.parseUnits("1", 0); // 1 WETH
+    const min = ethers.utils.parseUnits("1", 0); // 1
     // The maximum increase in the rate per update
-    const maxIncrease = BigNumber.from(10000); // 10,000 WETH
+    const maxIncrease = BigNumber.from(5_000);
     // The maximum decrease in the rate per update
-    const maxDecrease = BigNumber.from(0); // 0 WETH
+    const maxDecrease = BigNumber.from(0); // 0
     // The maximum percent increase in the rate per update
     const maxPercentIncrease = BigNumber.from(2000); // 20%
     // The maximum percent decrease in the rate per update
     const maxPercentDecrease = BigNumber.from(0); // 0%
     // The base rate
-    const baseRate = BigNumber.from(0); // 0 WETH
+    const baseRate = BigNumber.from(0); // 0
     // Dynamic rate components
     const dynamicRateComponents = [
         {
-            address: "0xB2384aa8EA7374d5558e1d09c93304C086609821", // AaveV3SupplyMutationComputer on Polygon
+            address: POLYGON_AAVE_V3_SUPPLY_CAP_COMPUTER, // Aave v3 supply cap computer on Polygon
             weight: BigNumber.from(10000), // 100%
         },
     ];

--- a/test/accumulators/managed-liquidity-accumulator.js
+++ b/test/accumulators/managed-liquidity-accumulator.js
@@ -117,6 +117,15 @@ function describeLiquidityAccumulatorTests(
 
             await expect(accumulator.setConfig(config)).to.be.revertedWith("InvalidConfig");
         });
+
+        it("Reverts if the heartbeat is zero", async function () {
+            const config = {
+                ...DEFAULT_CONFIG,
+                heartbeat: 0,
+            };
+
+            await expect(accumulator.setConfig(config)).to.be.revertedWith("InvalidConfig");
+        });
     });
 
     describe(contractName + "#update", function () {

--- a/test/accumulators/managed-liquidity-accumulator.js
+++ b/test/accumulators/managed-liquidity-accumulator.js
@@ -126,6 +126,10 @@ function describeLiquidityAccumulatorTests(
 
             await expect(accumulator.setConfig(config)).to.be.revertedWith("InvalidConfig");
         });
+
+        it("Reverts if the config remains unchanged", async function () {
+            await expect(accumulator.setConfig(DEFAULT_CONFIG)).to.be.revertedWith("ConfigUnchanged");
+        });
     });
 
     describe(contractName + "#update", function () {

--- a/test/accumulators/managed-liquidity-accumulator.js
+++ b/test/accumulators/managed-liquidity-accumulator.js
@@ -121,6 +121,7 @@ function describeLiquidityAccumulatorTests(
         it("Reverts if the heartbeat is zero", async function () {
             const config = {
                 ...DEFAULT_CONFIG,
+                updateDelay: 0,
                 heartbeat: 0,
             };
 

--- a/test/accumulators/managed-price-accumulator.js
+++ b/test/accumulators/managed-price-accumulator.js
@@ -130,6 +130,7 @@ function describePriceAccumulatorTests(
         it("Reverts if the heartbeat is zero", async function () {
             const config = {
                 ...DEFAULT_CONFIG,
+                updateDelay: 0,
                 heartbeat: 0,
             };
 

--- a/test/accumulators/managed-price-accumulator.js
+++ b/test/accumulators/managed-price-accumulator.js
@@ -126,6 +126,15 @@ function describePriceAccumulatorTests(
 
             await expect(accumulator.setConfig(config)).to.be.revertedWith("InvalidConfig");
         });
+
+        it("Reverts if the heartbeat is zero", async function () {
+            const config = {
+                ...DEFAULT_CONFIG,
+                heartbeat: 0,
+            };
+
+            await expect(accumulator.setConfig(config)).to.be.revertedWith("InvalidConfig");
+        });
     });
 
     describe(contractName + "#update", function () {

--- a/test/accumulators/managed-price-accumulator.js
+++ b/test/accumulators/managed-price-accumulator.js
@@ -135,6 +135,10 @@ function describePriceAccumulatorTests(
 
             await expect(accumulator.setConfig(config)).to.be.revertedWith("InvalidConfig");
         });
+
+        it("Reverts if the config remains unchanged", async function () {
+            await expect(accumulator.setConfig(DEFAULT_CONFIG)).to.be.revertedWith("ConfigUnchanged");
+        });
     });
 
     describe(contractName + "#update", function () {

--- a/test/oracles/managed-aggregator-oracle.js
+++ b/test/oracles/managed-aggregator-oracle.js
@@ -476,6 +476,26 @@ function describeManagedAggregatorOracleTests(contractName, deployFunction) {
             await oracle.setUpdatesPaused(WETH, false);
             expect(await oracle.canUpdate(ethers.utils.hexZeroPad(WETH, 32))).to.equal(true);
         });
+
+        it("Reverts when the pause status remains unchanged (paused = false)", async function () {
+            // Sanity check that the pause status is false
+            expect(await oracle.areUpdatesPaused(WETH)).to.equal(false);
+
+            await expect(oracle.setUpdatesPaused(WETH, false))
+                .to.be.revertedWith("PauseStatusUnchanged")
+                .withArgs(WETH, false);
+        });
+
+        it("Reverts when the pause status remains unchanged (paused = true)", async function () {
+            await oracle.setUpdatesPaused(WETH, true);
+
+            // Sanity check that the pause status is true
+            expect(await oracle.areUpdatesPaused(WETH)).to.equal(true);
+
+            await expect(oracle.setUpdatesPaused(WETH, true))
+                .to.be.revertedWith("PauseStatusUnchanged")
+                .withArgs(WETH, true);
+        });
     });
 
     describe(contractName + "#setTokenConfig", function () {

--- a/test/oracles/managed-aggregator-oracle.js
+++ b/test/oracles/managed-aggregator-oracle.js
@@ -322,6 +322,16 @@ describe("ManagedCurrentAggregatorOracle#setConfig", function () {
 
         await expect(oracle.setConfig(newConfig)).to.be.revertedWith("InvalidConfig");
     });
+
+    it("Reverts if the new config is the same as the old config", async function () {
+        const newConfig = {
+            updateThreshold: DEFAULT_UPDATE_THRESHOLD,
+            updateDelay: DEFAULT_UPDATE_DELAY,
+            heartbeat: DEFAULT_HEARTBEAT,
+        };
+
+        await expect(oracle.setConfig(newConfig)).to.be.revertedWith("ConfigUnchanged");
+    });
 });
 
 function describeManagedAggregatorOracleTests(contractName, deployFunction) {

--- a/test/oracles/managed-aggregator-oracle.js
+++ b/test/oracles/managed-aggregator-oracle.js
@@ -801,6 +801,22 @@ function describeManagedAggregatorOracleTests(contractName, deployFunction) {
                 .to.be.revertedWith("InvalidTokenConfig")
                 .withArgs(invalidTokenConfig.address, ERROR_INVALID_ORACLE);
         });
+
+        it("Reverts if the token config remains unchanged (with a non-zero config address)", async function () {
+            await expect(oracle.setTokenConfig(WETH, alternativeTokenConfig.address))
+                .to.emit(oracle, "TokenConfigUpdated")
+                .withArgs(WETH, ethers.constants.AddressZero, alternativeTokenConfig.address);
+
+            await expect(oracle.setTokenConfig(WETH, alternativeTokenConfig.address)).to.be.revertedWith(
+                "TokenConfigUnchanged"
+            );
+        });
+
+        it("Reverts if the token config remains unchanged (with a zero config address)", async function () {
+            await expect(oracle.setTokenConfig(WETH, ethers.constants.AddressZero)).to.be.revertedWith(
+                "TokenConfigUnchanged"
+            );
+        });
     });
 
     describe(contractName + "#update", function () {

--- a/test/oracles/managed-historical-aggregator-oracle.js
+++ b/test/oracles/managed-historical-aggregator-oracle.js
@@ -451,6 +451,19 @@ function describeManagedHistoricalAggregatorOracleTests(contractName, deployFunc
                 .to.be.revertedWith("InvalidConfig")
                 .withArgs(Object.values(config), ERROR_INVALID_SOURCE_DECIMAL_MISMATCH);
         });
+
+        it("Reverts if the new config is the same as the current one", async function () {
+            const config = {
+                source: source.address,
+                observationAmount: DEFAULT_OBSERVATION_AMOUNT,
+                observationOffset: DEFAULT_OBSERVATION_OFFSET,
+                observationIncrement: DEFAULT_OBSERVATION_INCREMENT,
+            };
+
+            await expect(oracle.setConfig(config))
+                .to.be.revertedWith("ConfigUnchanged")
+                .withArgs(Object.values(config));
+        });
     });
 
     describe(contractName + "#update", function () {

--- a/test/oracles/managed-historical-aggregator-oracle.js
+++ b/test/oracles/managed-historical-aggregator-oracle.js
@@ -267,6 +267,26 @@ function describeManagedHistoricalAggregatorOracleTests(contractName, deployFunc
             await oracle.setUpdatesPaused(WETH, false);
             expect(await oracle.canUpdate(ethers.utils.hexZeroPad(WETH, 32))).to.equal(true);
         });
+
+        it("Reverts when the pause status remains unchanged (paused = false)", async function () {
+            // Sanity check that the pause status is false
+            expect(await oracle.areUpdatesPaused(WETH)).to.equal(false);
+
+            await expect(oracle.setUpdatesPaused(WETH, false))
+                .to.be.revertedWith("PauseStatusUnchanged")
+                .withArgs(WETH, false);
+        });
+
+        it("Reverts when the pause status remains unchanged (paused = true)", async function () {
+            await oracle.setUpdatesPaused(WETH, true);
+
+            // Sanity check that the pause status is true
+            expect(await oracle.areUpdatesPaused(WETH)).to.equal(true);
+
+            await expect(oracle.setUpdatesPaused(WETH, true))
+                .to.be.revertedWith("PauseStatusUnchanged")
+                .withArgs(WETH, true);
+        });
     });
 
     describe(contractName + "#setConfig", function () {

--- a/test/rates/rate-controller.js
+++ b/test/rates/rate-controller.js
@@ -212,20 +212,20 @@ describe("RateController#setUpdatesPaused", function () {
         expect(await controller.areUpdatesPaused(GRT)).to.equal(false);
     });
 
-    it("Should not emit an event when the update status is unchanged (paused = false)", async function () {
-        await expect(controller.setUpdatesPaused(GRT, false)).to.not.emit(controller, "PauseStatusChanged");
+    it("Should revert when the update status is unchanged (paused = false)", async function () {
+        await expect(controller.setUpdatesPaused(GRT, false)).to.be.revertedWith("PauseStatusUnchanged");
 
         // Sanity check that the status is the same
         expect(await controller.areUpdatesPaused(GRT)).to.equal(false);
     });
 
-    it("Should not emit an event when the update status is unchanged (paused = true)", async function () {
+    it("Should revert when the update status is unchanged (paused = true)", async function () {
         await controller.setUpdatesPaused(GRT, true);
 
         // Sanity check that the changes were made
         expect(await controller.areUpdatesPaused(GRT)).to.equal(true);
 
-        await expect(controller.setUpdatesPaused(GRT, true)).to.not.emit(controller, "PauseStatusChanged");
+        await expect(controller.setUpdatesPaused(GRT, true)).to.be.revertedWith("PauseStatusUnchanged");
 
         // Sanity check that the status is the same
         expect(await controller.areUpdatesPaused(GRT)).to.equal(true);
@@ -245,7 +245,7 @@ describe("RateController#setUpdatesPaused", function () {
 
     it("Should not call onPaused when the updates are paused, but they're already paused", async function () {
         await controller.setUpdatesPaused(GRT, true);
-        await controller.setUpdatesPaused(GRT, true);
+        await expect(controller.setUpdatesPaused(GRT, true)).to.be.revertedWith("PauseStatusUnchanged");
 
         // Sanity check that the changes were made
         expect(await controller.areUpdatesPaused(GRT)).to.equal(true);
@@ -274,7 +274,7 @@ describe("RateController#setUpdatesPaused", function () {
     });
 
     it("Should not call onPaused when the updates are unpaused, but they're already unpaused", async function () {
-        await controller.setUpdatesPaused(GRT, false);
+        await expect(controller.setUpdatesPaused(GRT, false)).to.be.revertedWith("PauseStatusUnchanged");
 
         // Sanity check that the changes were made
         expect(await controller.areUpdatesPaused(GRT)).to.equal(false);

--- a/test/rates/rate-controller.js
+++ b/test/rates/rate-controller.js
@@ -793,14 +793,19 @@ describe("RateController#computeRate", function () {
             components: [ethers.utils.parseUnits("0", 18), ethers.utils.parseUnits("0", 18)], // 0%, 0%
             componentWeights: [2500, 2500], // 25%, 25%
         },
+        {
+            base: ethers.utils.parseUnits("0", 18), // 0%
+            components: [BigNumber.from(1), BigNumber.from(1), BigNumber.from(1), BigNumber.from(1)],
+            componentWeights: [2500, 2500, 2500, 2500], // 25%, 25%, 25%, 25%
+        },
     ];
 
     function getRate(base, components, componentWeights) {
-        var rate = base;
+        var rateNum = BigNumber.from(0);
         for (var i = 0; i < components.length; ++i) {
-            rate = rate.add(components[i].mul(componentWeights[i]).div(10000));
+            rateNum = rateNum.add(components[i].mul(componentWeights[i]));
         }
-        return rate;
+        return base.add(rateNum.div(10000));
     }
 
     for (var i = 0; i < tests.length; ++i) {

--- a/test/rates/rate-controller.js
+++ b/test/rates/rate-controller.js
@@ -469,6 +469,16 @@ describe("RateController#setConfig", function () {
         await expect(controller.setConfig(GRT, config)).to.be.revertedWith("InvalidConfig").withArgs(GRT);
     });
 
+    it("Should revert when a duplicate component is provided", async function () {
+        const config = {
+            ...DEFAULT_CONFIG,
+            componentWeights: [1, 1],
+            components: [computer.address, computer.address],
+        };
+
+        await expect(controller.setConfig(GRT, config)).to.be.revertedWith("InvalidConfig").withArgs(GRT);
+    });
+
     it("Should emit a RateConfigUpdated event if the config is valid", async function () {
         const tx = await controller.setConfig(GRT, DEFAULT_CONFIG);
 

--- a/test/rates/rate-controller.js
+++ b/test/rates/rate-controller.js
@@ -479,6 +479,16 @@ describe("RateController#setConfig", function () {
         await expect(controller.setConfig(GRT, config)).to.be.revertedWith("InvalidConfig").withArgs(GRT);
     });
 
+    it("Should revert if a component weight is zero", async function () {
+        const config = {
+            ...DEFAULT_CONFIG,
+            componentWeights: [0],
+            components: [computer.address],
+        };
+
+        await expect(controller.setConfig(GRT, config)).to.be.revertedWith("InvalidConfig").withArgs(GRT);
+    });
+
     it("Should emit a RateConfigUpdated event if the config is valid", async function () {
         const tx = await controller.setConfig(GRT, DEFAULT_CONFIG);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adrastia-oracle/adrastia-core@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@adrastia-oracle/adrastia-core/-/adrastia-core-4.1.0.tgz#8f34f7c4bf80168748aa61eb281f4b1f07e72c8d"
-  integrity sha512-bUB5EQnx7PawYMhXhLN0geelI0fEIUtKX/lgciKG6RhD1+3qXCucT2zad8j4emf1FEFcS9w3G9l6z104Ka8XHw==
+"@adrastia-oracle/adrastia-core@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@adrastia-oracle/adrastia-core/-/adrastia-core-4.2.0.tgz#2a6b8ad70b752841c9282641a4485a35d85d4971"
+  integrity sha512-Si+EKFmHwe3IYUbjEEZ7un7v7f6alJWW6PdF0Zj1xp8+OZOlDDBJGK9gB5i8YoVbswp+3TNEPiNxCNb3iXq8/Q==
   dependencies:
     "@openzeppelin-v4/contracts" "npm:@openzeppelin/contracts@4.6.0"
     "@prb/math" "^2.5.0"


### PR DESCRIPTION
### Dependencies
- Upgrade adrastia-core to v4.2.0.

### Accumulators
- Ensure heartbeat is not zero in setConfig
- Revert if the config is unchanged in setConfig

### Oracles
- Revert if the pause status is unchanged in setUpdatesPaused
- Revert if the token config is unchanged in setTokenConfig
- Revert if the config is unchanged in setConfig

### Prudentia
#### Controllers
- Revert if a component has zero weight in setConfig
- Revert if duplicate components are provided in setConfig
- Revert if the pause status is unchanged in setUpdatesPaused
- Fix precision loss error in computeRateInternal