### PR TITLE
Release/v4.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v4.6.1
+### Dependencies
+- Upgrade adrastia-core to v4.6.1.
+
+### Accumulators
+- Update ManagedCompoundV2SBAccumulator, ManagedIonicSBAccumulator, and ManagedVenusIsolatedV2SBAccumulator: Out of an abundance of caution, only those with the CONFIG_ADMIN role can refresh token mappings.
+
 ## v4.6.0
 ### Dependencies
 - Upgrade adrastia-core to v4.6.0.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adrastia Periphery
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![3801 out of 3801 tests passing](https://img.shields.io/badge/tests-3801/3801%20passing-brightgreen.svg?style=flat-square)
+![3819 out of 3819 tests passing](https://img.shields.io/badge/tests-3819/3819%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Adrastia Periphery is a set of Solidity smart contracts that complement the [Adrastia Core](https://github.com/adrastia-oracle/adrastia-core) smart contracts.

--- a/contracts/accumulators/proto/compound/ManagedCompoundV2SBAccumulator.sol
+++ b/contracts/accumulators/proto/compound/ManagedCompoundV2SBAccumulator.sol
@@ -25,6 +25,10 @@ contract ManagedCompoundV2SBAccumulator is CompoundV2SBAccumulator, AccumulatorC
         AccumulatorConfig(uint32(updateTheshold_), uint32(minUpdateDelay_), uint32(maxUpdateDelay_))
     {}
 
+    function refreshTokenMappings() external virtual override onlyRole(Roles.CONFIG_ADMIN) {
+        _refreshTokenMappings();
+    }
+
     function canUpdate(bytes memory data) public view virtual override returns (bool) {
         // Return false if the message sender is missing the required role
         if (!hasRole(Roles.ORACLE_UPDATER, address(0)) && !hasRole(Roles.ORACLE_UPDATER, msg.sender)) return false;

--- a/contracts/accumulators/proto/ionic/ManagedIonicSBAccumulator.sol
+++ b/contracts/accumulators/proto/ionic/ManagedIonicSBAccumulator.sol
@@ -25,6 +25,10 @@ contract ManagedIonicSBAccumulator is IonicSBAccumulator, AccumulatorConfig {
         AccumulatorConfig(uint32(updateTheshold_), uint32(minUpdateDelay_), uint32(maxUpdateDelay_))
     {}
 
+    function refreshTokenMappings() external virtual override onlyRole(Roles.CONFIG_ADMIN) {
+        _refreshTokenMappings();
+    }
+
     function canUpdate(bytes memory data) public view virtual override returns (bool) {
         // Return false if the message sender is missing the required role
         if (!hasRole(Roles.ORACLE_UPDATER, address(0)) && !hasRole(Roles.ORACLE_UPDATER, msg.sender)) return false;

--- a/contracts/accumulators/proto/venus/ManagedVenusIsolatedSBAccumulator.sol
+++ b/contracts/accumulators/proto/venus/ManagedVenusIsolatedSBAccumulator.sol
@@ -25,6 +25,10 @@ contract ManagedVenusIsolatedSBAccumulator is VenusIsolatedSBAccumulator, Accumu
         AccumulatorConfig(uint32(updateTheshold_), uint32(minUpdateDelay_), uint32(maxUpdateDelay_))
     {}
 
+    function refreshTokenMappings() external virtual override onlyRole(Roles.CONFIG_ADMIN) {
+        _refreshTokenMappings();
+    }
+
     function canUpdate(bytes memory data) public view virtual override returns (bool) {
         // Return false if the message sender is missing the required role
         if (!hasRole(Roles.ORACLE_UPDATER, address(0)) && !hasRole(Roles.ORACLE_UPDATER, msg.sender)) return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrastia-oracle/adrastia-periphery",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "BUSL-1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adrastia-oracle/adrastia-core": "4.6.0",
+    "@adrastia-oracle/adrastia-core": "4.6.1",
     "@openzeppelin-v3/contracts": "npm:@openzeppelin/contracts@3.4.2",
     "@openzeppelin-v4/contracts": "npm:@openzeppelin/contracts@4.6.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adrastia-oracle/adrastia-core@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@adrastia-oracle/adrastia-core/-/adrastia-core-4.6.0.tgz#ded7ea24435d611fd4ed2909f50cc82ddf2d7b66"
-  integrity sha512-Ekjz2EZnuQfvGTG2Ro35q/s4A4P+48aFkr2WptIcqb9rT59YmTf/V9CkZygh9WTEbAnlutUrs0SAcPZK/PvyfA==
+"@adrastia-oracle/adrastia-core@4.6.1":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@adrastia-oracle/adrastia-core/-/adrastia-core-4.6.1.tgz#4d3218fa6ddbc64e807f813a5bdd2f8c4c1165bf"
+  integrity sha512-OXs0jTxsMjZFMh2Se7ABukYGMMYm23UdIcCpGMl0jLMoEEUbIRWW7spYto1ai3nr17AV5xPJXEEPrNpdVKp4Zw==
   dependencies:
     "@openzeppelin-v4/contracts" "npm:@openzeppelin/contracts@4.6.0"
     "@prb/math" "^2.5.0"


### PR DESCRIPTION
### Dependencies
- Upgrade adrastia-core to v4.6.1.

### Accumulators
- Update ManagedCompoundV2SBAccumulator, ManagedIonicSBAccumulator, and ManagedVenusIsolatedV2SBAccumulator: Out of an abundance of caution, only those with the CONFIG_ADMIN role can refresh token mappings.