### PR TITLE
Release/v4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.9.0
 ### Dependencies
+- Upgrade adrastia-core to v4.9.0.
 - Upgrade OpenZeppelin Contracts to v4.9.6
 
 ### Accumulators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v4.9.0
+### Dependencies
+- Upgrade OpenZeppelin Contracts to v4.9.6
+
+### Accumulators
+- Add ManagedSAVPriceAccumulator: A managed accumulator that tracks ERC4626 vault share prices.
+
 ## v4.8.1
 ### Prudentia
 #### Controllers

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adrastia Periphery
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![3953 out of 3953 tests passing](https://img.shields.io/badge/tests-3953/3953%20passing-brightgreen.svg?style=flat-square)
+![4015 out of 4015 tests passing](https://img.shields.io/badge/tests-4015/4015%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Adrastia Periphery is a set of Solidity smart contracts that complement the [Adrastia Core](https://github.com/adrastia-oracle/adrastia-core) smart contracts.

--- a/contracts/accumulators/proto/balancer/ManagedBalancerV2StablePriceAccumulator.sol
+++ b/contracts/accumulators/proto/balancer/ManagedBalancerV2StablePriceAccumulator.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.13;
 
-import "@adrastia-oracle/adrastia-core/contracts/accumulators/proto/balancer/BalancerV2StablePriceAccumulator.sol";
+import {BalancerV2StablePriceAccumulator, IAveragingStrategy, PriceAccumulator} from "@adrastia-oracle/adrastia-core/contracts/accumulators/proto/balancer/BalancerV2StablePriceAccumulator.sol";
 
-import "../../AccumulatorConfig.sol";
+import {AccumulatorConfig, AccessControlEnumerable, Roles} from "../../AccumulatorConfig.sol";
 
 contract ManagedBalancerV2StablePriceAccumulator is BalancerV2StablePriceAccumulator, AccumulatorConfig {
     constructor(

--- a/contracts/accumulators/proto/erc4626/ManagedSAVPriceAccumulator.sol
+++ b/contracts/accumulators/proto/erc4626/ManagedSAVPriceAccumulator.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.13;
+
+import "@adrastia-oracle/adrastia-core/contracts/accumulators/proto/erc4626/SAVPriceAccumulator.sol";
+
+import "@openzeppelin-v4/contracts/access/AccessControlEnumerable.sol";
+
+import "../../AccumulatorConfig.sol";
+import "../../../access/Roles.sol";
+
+contract ManagedSAVPriceAccumulator is AccessControlEnumerable, SAVPriceAccumulator, AccumulatorConfig {
+    constructor(
+        IPriceOracle underlyingOracle_,
+        IAveragingStrategy averagingStrategy_,
+        address quoteToken_,
+        uint256 updateTheshold_,
+        uint256 minUpdateDelay_,
+        uint256 maxUpdateDelay_
+    )
+        SAVPriceAccumulator(
+            underlyingOracle_,
+            averagingStrategy_,
+            quoteToken_,
+            updateTheshold_,
+            minUpdateDelay_,
+            maxUpdateDelay_
+        )
+        AccumulatorConfig(uint32(updateTheshold_), uint32(minUpdateDelay_), uint32(maxUpdateDelay_))
+    {}
+
+    function canUpdate(bytes memory data) public view virtual override returns (bool) {
+        // Return false if the message sender is missing the required role
+        if (!hasRole(Roles.ORACLE_UPDATER, address(0)) && !hasRole(Roles.ORACLE_UPDATER, msg.sender)) return false;
+
+        return super.canUpdate(data);
+    }
+
+    function update(bytes memory data) public virtual override onlyRoleOrOpenRole(Roles.ORACLE_UPDATER) returns (bool) {
+        return super.update(data);
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(AccessControlEnumerable, PriceAccumulator) returns (bool) {
+        return
+            AccessControlEnumerable.supportsInterface(interfaceId) || PriceAccumulator.supportsInterface(interfaceId);
+    }
+
+    function _updateDelay() internal view virtual override returns (uint256) {
+        return config.updateDelay;
+    }
+
+    function _heartbeat() internal view virtual override returns (uint256) {
+        return config.heartbeat;
+    }
+
+    function _updateThreshold() internal view virtual override returns (uint256) {
+        return config.updateThreshold;
+    }
+}

--- a/contracts/test/accumulators/InputAndErrorAccumulatorStub.sol
+++ b/contracts/test/accumulators/InputAndErrorAccumulatorStub.sol
@@ -2,11 +2,8 @@
 pragma solidity =0.8.13;
 
 import "@adrastia-oracle/adrastia-core/contracts/interfaces/ILiquidityOracle.sol";
-import "@adrastia-oracle/adrastia-core/contracts/libraries/SafeCastExt.sol";
 
 contract InputAndErrorAccumulatorStub is ILiquidityOracle {
-    using SafeCastExt for uint256;
-
     struct InputAndError {
         uint112 input;
         uint112 target;

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@adrastia-oracle/adrastia-core": "4.8.0",
+    "@adrastia-oracle/adrastia-core": "4.9.0",
     "@openzeppelin-v3/contracts": "npm:@openzeppelin/contracts@3.4.2",
-    "@openzeppelin-v4/contracts": "npm:@openzeppelin/contracts@4.6.0"
+    "@openzeppelin-v4/contracts": "npm:@openzeppelin/contracts@4.9.6"
   },
   "devDependencies": {
     "@atixlabs/hardhat-time-n-mine": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrastia-oracle/adrastia-periphery",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "BUSL-1.1",

--- a/scripts/oracles/deploy-oracle-aggregator-config.js
+++ b/scripts/oracles/deploy-oracle-aggregator-config.js
@@ -26,6 +26,9 @@ const oracles = {
         "pyth-eth-usd": "0x4e22Ea0CB77B5aE0085551EF0fC5026C82c07e1D",
         "median-dao-usd": "0x41F14ed7e7E8034a5EB4EC72BdE3C94F91ECfa10",
         "liquidation-oracle-usd": "0x9EdaB5295260AC27c13564E4827b73408C132270",
+        "chainlink-ezeth-eth": "0x33eAdF30fBf8f91759E1A15571Fa157B2cCb7a12", // 4h TWAP, 1 granularity
+        "chainlink-rseth-eth": "0x400f109C7FBD51A84B388CeAa8497Cdee659FEF4", // 4h TWAP, 1 granularity
+        "chainlink-weeth-eth": "0xe781741Cdb6e1335163946ac011C88de67963fE9", // 4h TWAP, 1 granularity
     },
     optimism: {
         "chainlink-eth-usd": "0x00922ad039612B8b2DD9a8b10e6a834cec74B9DC",
@@ -42,19 +45,19 @@ const oracles = {
 };
 
 async function main() {
-    const chain = "optimism";
+    const chain = "arbitrum";
 
     // The address of the aggregation strategy.
-    const aggregationStrategy = aggregationStrategies[chain].maximum;
+    const aggregationStrategy = aggregationStrategies[chain].median;
 
     // The address of the validation strategy. Can be the zero address to skip validation.
     const validationStrategy = ethers.constants.AddressZero;
 
     // The minimum number of underlying oracle responses required to perform an update.
-    const minimumResponses = 2;
+    const minimumResponses = 1;
 
     // An array of the underlying oracle addresses.
-    const oracles_ = [oracles[chain]["median-dao-usd"], oracles[chain]["liquidation-oracle-usd"]];
+    const oracles_ = [oracles[chain]["chainlink-weeth-eth"]];
 
     const factory = await ethers.getContractFactory("OracleAggregatorTokenConfig");
     const config = await factory.deploy(aggregationStrategy, validationStrategy, minimumResponses, oracles_);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@adrastia-oracle/adrastia-core@4.8.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@adrastia-oracle/adrastia-core/-/adrastia-core-4.8.0.tgz#3eb9f7b93ada156ea2be9439e2e41f5ecf07cdb4"
-  integrity sha512-iGAgKwLzJE+PE/TDtXRUQxiyF7zqdgtCv5QZj03PxORiLuoQbL0Q9rh8awhrXm6MoOJ2AVrn4T8X7/KFtx1/GQ==
+"@adrastia-oracle/adrastia-core@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@adrastia-oracle/adrastia-core/-/adrastia-core-4.9.0.tgz#26723a35d1061ec6da3a9444f7a06060dc71ea12"
+  integrity sha512-kPKd10W2IfmCXsr+ym8bzQWAcro7NeW8Bj3I8AqwWMZ9YTWR+s3Au6NFZymwf+osOROJma1bz23Lqv8L92RZxw==
   dependencies:
-    "@openzeppelin-v4/contracts" "npm:@openzeppelin/contracts@4.6.0"
+    "@openzeppelin-v4/contracts" "npm:@openzeppelin/contracts@4.9.6"
     "@prb/math" "^2.5.0"
     "@uniswap/v2-core" "^1.0.1"
     "@uniswap/v3-core" "^1.0.1"
@@ -893,10 +893,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2.tgz#d81f786fda2871d1eb8a8c5a73e455753ba53527"
   integrity sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==
 
-"@openzeppelin-v4/contracts@npm:@openzeppelin/contracts@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
-  integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
+"@openzeppelin-v4/contracts@npm:@openzeppelin/contracts@4.9.6":
+  version "4.9.6"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.6.tgz#2a880a24eb19b4f8b25adc2a5095f2aa27f39677"
+  integrity sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==
 
 "@prb/math@^2.5.0":
   version "2.5.0"


### PR DESCRIPTION
### Dependencies
- Upgrade adrastia-core to v4.9.0.
- Upgrade OpenZeppelin Contracts to v4.9.6

### Accumulators
- Add ManagedSAVPriceAccumulator: A managed accumulator that tracks ERC4626 vault share prices.