### PR TITLE
Release/v4.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.9.1
+### Prudentia
+#### Controllers
+- Allow pausing updates for a token without a configuration: This allows us to manually push rates (which requires a config) before any updates occur.
+- Add another kickback prevention to PidController#manuallyPushRate and PidController unpausing.
+
 ## v4.9.0
 ### Dependencies
 - Upgrade adrastia-core to v4.9.0.

--- a/contracts/rates/RateController.sol
+++ b/contracts/rates/RateController.sol
@@ -192,13 +192,8 @@ abstract contract RateController is ERC165, HistoricalRates, IRateComputer, IUpd
         checkSetUpdatesPaused();
 
         BufferMetadata storage meta = rateBufferMetadata[token];
-        if (meta.maxSize == 0) {
-            // Uninitialized buffer means that the rate config is missing
-            // It doesn't make sense to pause updates if they can't occur in the first place
-            revert MissingConfig(token);
-        }
 
-        uint16 flags = rateBufferMetadata[token].flags;
+        uint16 flags = meta.flags;
 
         bool currentlyPaused = (flags & PAUSE_FLAG_MASK) != 0;
         if (currentlyPaused != paused) {
@@ -208,7 +203,7 @@ abstract contract RateController is ERC165, HistoricalRates, IRateComputer, IUpd
                 flags &= ~PAUSE_FLAG_MASK;
             }
 
-            rateBufferMetadata[token].flags = flags;
+            meta.flags = flags;
 
             emit PauseStatusChanged(token, paused);
 

--- a/contracts/rates/computers/MutatedValueComputer.sol
+++ b/contracts/rates/computers/MutatedValueComputer.sol
@@ -127,11 +127,11 @@ abstract contract MutatedValueComputer is IERC165, IRateComputer {
     }
 
     /**
-     * @notice Returns the mutated value for a given token.
+     * @notice Returns the raw value for a given token which will later be mutated.
      * @dev This is an internal virtual function that must be implemented by the derived contract to provide the
-     *   specific logic for extracting the mutated value for the token.
-     * @param token The token address for which the mutated value should be computed.
-     * @return The mutated value for the given token.
+     *   specific logic for extracting the raw value for the token.
+     * @param token The token address for which the raw value should be computed.
+     * @return The raw value for the given token.
      */
     function getValue(address token) internal view virtual returns (uint256);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrastia-oracle/adrastia-periphery",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "BUSL-1.1",

--- a/test/rates/rate-controller.js
+++ b/test/rates/rate-controller.js
@@ -4161,6 +4161,7 @@ function createDescribeCanUpdateTests(isPidController) {
 function describeTests(
     contractName,
     deployFunc,
+    setDefaultConfigFunc,
     describeComputeRateTests,
     describeNeedsUpdateTests,
     describeUpdateTests,
@@ -4283,12 +4284,16 @@ function describeTests(
             await expect(controller.connect(signer).setUpdatesPaused(GRT, true)).to.not.be.reverted;
         });
 
-        it("Should revert if the token is missing a config", async function () {
-            await expect(controller.setUpdatesPaused(USDC, true)).to.be.revertedWith("MissingConfig").withArgs(USDC);
+        it("Should not revert if the token is missing a config", async function () {
+            await expect(controller.setUpdatesPaused(USDC, true))
+                .to.emit(controller, "PauseStatusChanged")
+                .withArgs(USDC, true);
 
-            // Sanity check that we can successfully call the function if we have the config
-            await controller.setConfig(USDC, DEFAULT_CONFIG);
-            await expect(controller.setUpdatesPaused(USDC, true)).to.not.be.reverted;
+            // Sanity check that the changes were made
+            expect(await controller.areUpdatesPaused(USDC)).to.equal(true);
+
+            // Sanity check that USDC is missing a config
+            await expect(controller.getConfig(USDC)).to.be.revertedWith("MissingConfig").withArgs(USDC);
         });
 
         it("Should emit an event when the updates are paused", async function () {
@@ -5692,10 +5697,7 @@ function describeTests(
             await controller.grantRole(UPDATE_PAUSE_ADMIN_ROLE, signer.address);
 
             // Set config for GRT
-            await controller.setConfig(GRT, DEFAULT_CONFIG);
-
-            // Set PID config for GRT
-            await controller.setPidConfig(GRT, DEFAULT_PID_CONFIG);
+            await setDefaultConfigFunc(controller, GRT);
         });
 
         it("Should revert if the caller does not have the ADMIN role", async function () {
@@ -5726,17 +5728,11 @@ function describeTests(
             const rate = ethers.utils.parseUnits("0.1234", 18);
 
             await expect(controller.manuallyPushRate(USDC, rate, rate, 1))
-                .to.be.revertedWith("MissingPidConfig")
-                .withArgs(USDC);
-
-            // Set config, and try again. We're still missing PID config
-            await controller.setConfig(USDC, DEFAULT_CONFIG);
-            await expect(controller.manuallyPushRate(USDC, rate, rate, 1))
-                .to.be.revertedWith("MissingPidConfig")
+                .to.be.revertedWith(/MissingPidConfig|MissingConfig/)
                 .withArgs(USDC);
 
             // Sanity check that it works if we set a config
-            await controller.setPidConfig(USDC, DEFAULT_PID_CONFIG);
+            await setDefaultConfigFunc(controller, USDC);
             await expect(controller.manuallyPushRate(USDC, rate, rate, 1)).to.not.be.reverted;
         });
 
@@ -5853,9 +5849,19 @@ async function initializePidController(controller) {
     await controller.setPidConfig(GRT, DEFAULT_PID_CONFIG);
 }
 
+async function setDefaultStandardConfig(controller, token) {
+    await controller.setConfig(token, DEFAULT_CONFIG);
+}
+
+async function setDefaultPidConfig(controller, token) {
+    await controller.setConfig(token, DEFAULT_CONFIG);
+    await controller.setPidConfig(token, DEFAULT_PID_CONFIG);
+}
+
 describeTests(
     "RateController",
     deployStandardController,
+    setDefaultStandardConfig,
     describeStandardControllerComputeRateTests,
     createDescribeStandardControllerNeedsUpdateTests(false, undefined, undefined),
     createDescribeStandardControllerUpdateTests(undefined, true, undefined),
@@ -5864,6 +5870,7 @@ describeTests(
 describeTests(
     "PidController",
     deployPidController,
+    setDefaultPidConfig,
     describePidControllerComputeRateTests,
     createDescribeStandardControllerNeedsUpdateTests(
         true,


### PR DESCRIPTION
### Prudentia
#### Controllers
- Allow pausing updates for a token without a configuration: This allows us to manually push rates (which requires a config) before any updates occur.
- Add another kickback prevention to PidController#manuallyPushRate and PidController unpausing.