### PR TITLE
Release/v4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.10.0
+### Prudentia
+#### Controllers
+- Add flag to enable or disable compute ahead logic: If enabled, the controller's computeRate function will calculate the rate on-the-fly with clamping. Otherwise, it will return the last stored rate.
+- Add IonicRateController: A RateController that computes rates for Ionic tokens, accruing interest on the underlying tokens before pushing new rates.
+
 ## v4.9.1
 ### Prudentia
 #### Controllers

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adrastia Periphery
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![4015 out of 4015 tests passing](https://img.shields.io/badge/tests-4015/4015%20passing-brightgreen.svg?style=flat-square)
+![4038 out of 4038 tests passing](https://img.shields.io/badge/tests-4038/4038%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Adrastia Periphery is a set of Solidity smart contracts that complement the [Adrastia Core](https://github.com/adrastia-oracle/adrastia-core) smart contracts.

--- a/contracts/rates/ManagedRateController.sol
+++ b/contracts/rates/ManagedRateController.sol
@@ -32,15 +32,18 @@ contract ManagedRateController is RateController, AccessControlEnumerable {
 
     /**
      * @notice Constructs the ManagedRateController contract.
+     * @param computeAhead_ True if the rates returned by computeRate should be computed on-the-fly with clamping;
+     * false if the returned rates should be the same as the last pushed rates (from the buffer).
      * @param period_ The period for the rate controller.
      * @param initialBufferCardinality_ The initial buffer cardinality for the rate controller.
      * @param updatersMustBeEoa_ A flag indicating if updaters must be externally owned accounts.
      */
     constructor(
+        bool computeAhead_,
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    ) RateController(period_, initialBufferCardinality_, updatersMustBeEoa_) {
+    ) RateController(computeAhead_, period_, initialBufferCardinality_, updatersMustBeEoa_) {
         initializeRoles();
     }
 

--- a/contracts/rates/controllers/CapController.sol
+++ b/contracts/rates/controllers/CapController.sol
@@ -26,15 +26,18 @@ abstract contract CapController is RateController {
 
     /**
      * @notice Constructs the CapController contract.
+     * @param computeAhead_ True if the rates returned by computeRate should be computed on-the-fly with clamping;
+     * false if the returned rates should be the same as the last pushed rates (from the buffer).
      * @param period_ The period of the rate controller.
      * @param initialBufferCardinality_ The initial cardinality of the rate buffers.
      * @param updatersMustBeEoa_ Whether or not the updaters must be EOA.
      */
     constructor(
+        bool computeAhead_,
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    ) RateController(period_, initialBufferCardinality_, updatersMustBeEoa_) {}
+    ) RateController(computeAhead_, period_, initialBufferCardinality_, updatersMustBeEoa_) {}
 
     /**
      * @notice Sets the change threshold for the specified token. When the rate changes by more than the threshold, an

--- a/contracts/rates/controllers/ManagedCapController.sol
+++ b/contracts/rates/controllers/ManagedCapController.sol
@@ -32,15 +32,18 @@ contract ManagedCapController is CapController, AccessControlEnumerable {
 
     /**
      * @notice Constructs the ManagedCapController contract.
+     * @param computeAhead_ True if the rates returned by computeRate should be computed on-the-fly with clamping;
+     * false if the returned rates should be the same as the last pushed rates (from the buffer).
      * @param period_ The period for the rate controller.
      * @param initialBufferCardinality_ The initial buffer cardinality for the rate controller.
      * @param updatersMustBeEoa_ A flag indicating if updaters must be externally owned accounts.
      */
     constructor(
+        bool computeAhead_,
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    ) CapController(period_, initialBufferCardinality_, updatersMustBeEoa_) {
+    ) CapController(computeAhead_, period_, initialBufferCardinality_, updatersMustBeEoa_) {
         initializeRoles();
     }
 

--- a/contracts/rates/controllers/ManagedPidController.sol
+++ b/contracts/rates/controllers/ManagedPidController.sol
@@ -30,15 +30,18 @@ contract ManagedPidController is PidController, AccessControlEnumerable {
 
     /// @notice Constructs the ManagedPidController.
     /// @param inputAndErrorOracle_ Oracle to provide input and error values.
+    /// @param computeAhead_ True if the rates returned by computeRate should be computed on-the-fly with clamping;
+    /// false if the returned rates should be the same as the last pushed rates (from the buffer).
     /// @param period_ The period for the rate controller.
     /// @param initialBufferCardinality_ Initial size of the buffer for rate storage.
     /// @param updatersMustBeEoa_ Flag to determine if updaters must be externally owned accounts.
     constructor(
         ILiquidityOracle inputAndErrorOracle_,
+        bool computeAhead_,
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    ) PidController(inputAndErrorOracle_, period_, initialBufferCardinality_, updatersMustBeEoa_) {
+    ) PidController(inputAndErrorOracle_, computeAhead_, period_, initialBufferCardinality_, updatersMustBeEoa_) {
         initializeRoles();
     }
 

--- a/contracts/rates/controllers/proto/aave/AaveRateController.sol
+++ b/contracts/rates/controllers/proto/aave/AaveRateController.sol
@@ -29,7 +29,7 @@ contract AaveRateController is RateController {
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    ) RateController(period_, initialBufferCardinality_, updatersMustBeEoa_) {
+    ) RateController(false, period_, initialBufferCardinality_, updatersMustBeEoa_) {
         aclManager = aclManager_;
     }
 

--- a/contracts/rates/controllers/proto/ionic/IonicRateController.sol
+++ b/contracts/rates/controllers/proto/ionic/IonicRateController.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.13;
 
-import "../../ManagedPidController.sol";
+import "../../../ManagedRateController.sol";
 import "../../../../vendor/ionic/IComptroller.sol";
 import "../../../../vendor/ionic/ICToken.sol";
 
-contract IonicPidController is ManagedPidController {
+contract IonicRateController is ManagedRateController {
     IComptroller public immutable comptroller;
 
     error CTokenNotFound(address token);
@@ -14,20 +14,11 @@ contract IonicPidController is ManagedPidController {
 
     constructor(
         IComptroller comptroller_,
-        ILiquidityOracle inputAndErrorOracle_,
         bool computeAhead_,
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    )
-        ManagedPidController(
-            inputAndErrorOracle_,
-            computeAhead_,
-            period_,
-            initialBufferCardinality_,
-            updatersMustBeEoa_
-        )
-    {
+    ) ManagedRateController(computeAhead_, period_, initialBufferCardinality_, updatersMustBeEoa_) {
         comptroller = comptroller_;
     }
 

--- a/contracts/rates/controllers/proto/truefi/TrueFiAlocPidController.sol
+++ b/contracts/rates/controllers/proto/truefi/TrueFiAlocPidController.sol
@@ -7,10 +7,19 @@ import "../../../../vendor/truefi/IAutomatedLineOfCredit.sol";
 contract TrueFiAlocPidController is ManagedPidController {
     constructor(
         ILiquidityOracle inputAndErrorOracle_,
+        bool computeAhead_,
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    ) ManagedPidController(inputAndErrorOracle_, period_, initialBufferCardinality_, updatersMustBeEoa_) {}
+    )
+        ManagedPidController(
+            inputAndErrorOracle_,
+            computeAhead_,
+            period_,
+            initialBufferCardinality_,
+            updatersMustBeEoa_
+        )
+    {}
 
     /// @dev Overridden to accrue interest for the prior rate before pushing the new rate.
     function push(address alocAddress, RateLibrary.Rate memory rate) internal virtual override {

--- a/contracts/test/rates/RateControllerStub.sol
+++ b/contracts/test/rates/RateControllerStub.sol
@@ -21,10 +21,11 @@ contract RateControllerStub is ManagedRateController {
     mapping(address => OnPauseCall) public onPauseCalls;
 
     constructor(
+        bool computeAhead_,
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    ) ManagedRateController(period_, initialBufferCardinality_, updatersMustBeEoa_) {}
+    ) ManagedRateController(computeAhead_, period_, initialBufferCardinality_, updatersMustBeEoa_) {}
 
     function stubPush(address token, uint64 target, uint64 current, uint32 timestamp) public {
         RateLibrary.Rate memory rate;

--- a/contracts/test/rates/controllers/CapControllerStub.sol
+++ b/contracts/test/rates/controllers/CapControllerStub.sol
@@ -14,10 +14,11 @@ contract CapControllerStub is ManagedCapController {
     Config public config;
 
     constructor(
+        bool computeAhead_,
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    ) ManagedCapController(period_, initialBufferCardinality_, updatersMustBeEoa_) {}
+    ) ManagedCapController(computeAhead_, period_, initialBufferCardinality_, updatersMustBeEoa_) {}
 
     function overrideNeedsUpdate(bool overridden, bool needsUpdate_) public {
         config.needsUpdateOverridden = overridden;

--- a/contracts/test/rates/controllers/PidControllerStub.sol
+++ b/contracts/test/rates/controllers/PidControllerStub.sol
@@ -22,10 +22,11 @@ contract PidControllerStub is ManagedPidController, InputAndErrorAccumulatorStub
     mapping(address => OnPauseCall) public onPauseCalls;
 
     constructor(
+        bool computeAhead_,
         uint32 period_,
         uint8 initialBufferCardinality_,
         bool updatersMustBeEoa_
-    ) ManagedPidController(this, period_, initialBufferCardinality_, updatersMustBeEoa_) {}
+    ) ManagedPidController(this, computeAhead_, period_, initialBufferCardinality_, updatersMustBeEoa_) {}
 
     function canUpdate(
         bytes memory data

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -5,6 +5,7 @@ require("hardhat-gas-reporter");
 require("hardhat-tracer");
 require("@atixlabs/hardhat-time-n-mine");
 require("@nomiclabs/hardhat-etherscan");
+require("hardhat-contract-sizer");
 
 const SOLC_8 = {
     version: "0.8.13",
@@ -34,6 +35,7 @@ module.exports = {
                     order: "fifo",
                 },
             },
+            allowUnlimitedContractSize: true,
         },
         polygon: {
             chainId: 137,
@@ -88,5 +90,9 @@ module.exports = {
                 },
             },
         ],
+    },
+    contractSizer: {
+        runOnCompile: true,
+        except: ["test"],
     },
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ethereum-waffle": "^4.0.10",
     "ethers": "^5.7.2",
     "hardhat": "2.14.1",
+    "hardhat-contract-sizer": "^2.10.0",
     "hardhat-gas-reporter": "^1.0.9",
     "hardhat-tracer": "^2.3.4",
     "prettier": "^2.8.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrastia-oracle/adrastia-periphery",
-  "version": "4.9.1",
+  "version": "4.10.0",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "BUSL-1.1",

--- a/test/rates/computers/historical-rates-computer.js
+++ b/test/rates/computers/historical-rates-computer.js
@@ -7,6 +7,7 @@ const { AddressZero } = ethers.constants;
 const DEFAULT_PERIOD = 100;
 const DEFAULT_INITIAL_BUFFER_CARDINALITY = 10;
 const DEFAULT_UPDATERS_MUST_BE_EAO = false;
+const DEFAULT_COMPUTE_AHEAD = true;
 
 const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 
@@ -20,6 +21,7 @@ describe("HistoricalRatesComputer#constructor", function () {
     it("Sets the default config a rate provider is provided", async function () {
         const rateControllerFactory = await ethers.getContractFactory("RateControllerStub");
         const rateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO
@@ -49,6 +51,7 @@ describe("HistoricalRatesComputer#constructor", function () {
     it("Sets the default config a rate provider is provided, with an alternative index and high availability", async function () {
         const rateControllerFactory = await ethers.getContractFactory("RateControllerStub");
         const rateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO
@@ -111,6 +114,7 @@ describe("HistoricalRatesComputer#computeRate", function () {
 
         const rateControllerFactory = await ethers.getContractFactory("RateControllerStub");
         rateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO
@@ -268,11 +272,13 @@ describe("HistoricalRatesComputer#setConfig", function () {
 
         const rateControllerFactory = await ethers.getContractFactory("RateControllerStub");
         rateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO
         );
         secondRateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO
@@ -509,6 +515,7 @@ describe("HistoricalRatesComputer#isUsingDefaultConfig", function () {
 
         const rateControllerFactory = await ethers.getContractFactory("RateControllerStub");
         rateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO
@@ -626,6 +633,7 @@ describe("HistoricalRatesComputer#revertToDefaultConfig", function () {
 
         const rateControllerFactory = await ethers.getContractFactory("RateControllerStub");
         rateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO
@@ -703,6 +711,7 @@ describe("HistoricalRatesComputer#getConfig", function () {
 
         const rateControllerFactory = await ethers.getContractFactory("RateControllerStub");
         rateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO
@@ -822,6 +831,7 @@ describe("HistoricalRatesComputer#computeRateIndex", function () {
 
         const rateControllerFactory = await ethers.getContractFactory("RateControllerStub");
         rateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO
@@ -932,6 +942,7 @@ describe("HistoricalRatesComputer - IHistoricalRates implementation", function (
         const [signer] = await ethers.getSigners();
 
         rateController = await rateControllerStubFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO

--- a/test/rates/computers/managed-historical-rates-computer.js
+++ b/test/rates/computers/managed-historical-rates-computer.js
@@ -7,6 +7,7 @@ const { AddressZero } = ethers.constants;
 const DEFAULT_PERIOD = 100;
 const DEFAULT_INITIAL_BUFFER_CARDINALITY = 10;
 const DEFAULT_UPDATERS_MUST_BE_EAO = false;
+const DEFAULT_COMPUTE_AHEAD = true;
 
 describe("ManagedHistoricalRatesComputer#setConfig", function () {
     var computerFactory;
@@ -29,6 +30,7 @@ describe("ManagedHistoricalRatesComputer#setConfig", function () {
 
         const rateControllerFactory = await ethers.getContractFactory("RateControllerStub");
         rateController = await rateControllerFactory.deploy(
+            DEFAULT_COMPUTE_AHEAD,
             DEFAULT_PERIOD,
             DEFAULT_INITIAL_BUFFER_CARDINALITY,
             DEFAULT_UPDATERS_MUST_BE_EAO

--- a/test/rates/controllers/cap-controller.js
+++ b/test/rates/controllers/cap-controller.js
@@ -16,6 +16,7 @@ const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const PERIOD = 100;
 const INITIAL_BUFFER_CARDINALITY = 2;
 const UPDATERS_MUST_BE_EOA = false;
+const COMPUTE_AHEAD = true;
 
 const TWO_PERCENT_CHANGE = ethers.utils.parseUnits("0.02", 8);
 
@@ -62,12 +63,14 @@ describe("CapController#constructor", function () {
         [1, 2], // period
         [1, 2], // initialBufferCardinality
         [false, true], // updatersMustBeEoa
+        [false, true], // computeAhead
     ];
 
     for (const test of combos(testCombinations)) {
         const period = test[0];
         const initialBufferCardinality = test[1];
         const updatersMustBeEoa = test[2];
+        const computeAhead = test[3];
 
         it(
             "Should deploy with period=" +
@@ -75,10 +78,18 @@ describe("CapController#constructor", function () {
                 ", initialBufferCardinality=" +
                 initialBufferCardinality +
                 ", updatersMustBeEoa=" +
-                updatersMustBeEoa,
+                updatersMustBeEoa +
+                ", computeAhead=" +
+                computeAhead,
             async function () {
-                const rateController = await factory.deploy(period, initialBufferCardinality, updatersMustBeEoa);
+                const rateController = await factory.deploy(
+                    computeAhead,
+                    period,
+                    initialBufferCardinality,
+                    updatersMustBeEoa
+                );
 
+                expect(await rateController.computeAhead()).to.equal(computeAhead);
                 expect(await rateController.period()).to.equal(period);
                 expect(await rateController.getRatesCapacity(GRT)).to.equal(initialBufferCardinality);
                 expect(await rateController.updatersMustBeEoa()).to.equal(updatersMustBeEoa);
@@ -95,7 +106,12 @@ describe("CapController#setRatesCapacity", function () {
 
     beforeEach(async () => {
         const controllerFactory = await ethers.getContractFactory("ManagedCapController");
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, UPDATERS_MUST_BE_EOA);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            UPDATERS_MUST_BE_EOA
+        );
 
         // Get our signer address
         const [signer] = await ethers.getSigners();
@@ -128,7 +144,12 @@ describe("CapController#setChangeThreshold", function () {
 
     beforeEach(async () => {
         const controllerFactory = await ethers.getContractFactory("ManagedCapController");
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, UPDATERS_MUST_BE_EOA);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            UPDATERS_MUST_BE_EOA
+        );
 
         // Get our signer address
         const [signer] = await ethers.getSigners();
@@ -198,7 +219,12 @@ describe("CapController#willAnythingChange", function () {
 
     beforeEach(async () => {
         const controllerFactory = await ethers.getContractFactory("CapControllerStub");
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, UPDATERS_MUST_BE_EOA);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            UPDATERS_MUST_BE_EOA
+        );
 
         // Get our signer address
         const [signer] = await ethers.getSigners();
@@ -382,7 +408,12 @@ describe("CapController#changeThresholdSurpassed", function () {
 
     beforeEach(async () => {
         const controllerFactory = await ethers.getContractFactory("CapControllerStub");
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, UPDATERS_MUST_BE_EOA);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            UPDATERS_MUST_BE_EOA
+        );
     });
 
     it("Returns true when the change is enormously large", async function () {
@@ -398,7 +429,12 @@ describe("CapController#update", function () {
     async function deploy(updatersMustBeEoa) {
         const controllerFactory = await ethers.getContractFactory("CapControllerStub");
 
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, updatersMustBeEoa);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            updatersMustBeEoa
+        );
 
         // Get our signer address
         const [signer] = await ethers.getSigners();
@@ -466,7 +502,12 @@ describe("CapController#manuallyPushRate", function () {
     beforeEach(async function () {
         const controllerFactory = await ethers.getContractFactory("CapControllerStub");
 
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, UPDATERS_MUST_BE_EOA);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            UPDATERS_MUST_BE_EOA
+        );
 
         // Get our signer address
         const [signer] = await ethers.getSigners();
@@ -560,7 +601,12 @@ describe("CapController#setUpdatesPaused", function () {
     beforeEach(async () => {
         const controllerFactory = await ethers.getContractFactory("CapControllerStub");
 
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, UPDATERS_MUST_BE_EOA);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            UPDATERS_MUST_BE_EOA
+        );
 
         // Get our signer address
         const [signer] = await ethers.getSigners();
@@ -626,7 +672,12 @@ describe("CapController#canUpdate", function () {
     async function deploy(updatersMustBeEOA) {
         const controllerFactory = await ethers.getContractFactory("CapControllerStub");
 
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, updatersMustBeEOA);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            updatersMustBeEOA
+        );
 
         // Get our signer address
         const [signer] = await ethers.getSigners();
@@ -708,7 +759,12 @@ describe("CapController#setConfig", function () {
     beforeEach(async () => {
         const controllerFactory = await ethers.getContractFactory("CapControllerStub");
 
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, UPDATERS_MUST_BE_EOA);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            UPDATERS_MUST_BE_EOA
+        );
 
         // Get our signer address
         const [signer] = await ethers.getSigners();
@@ -766,7 +822,12 @@ describe("CapController#supportsInterface", function () {
     beforeEach(async () => {
         const controllerFactory = await ethers.getContractFactory("ManagedCapController");
 
-        controller = await controllerFactory.deploy(PERIOD, INITIAL_BUFFER_CARDINALITY, UPDATERS_MUST_BE_EOA);
+        controller = await controllerFactory.deploy(
+            COMPUTE_AHEAD,
+            PERIOD,
+            INITIAL_BUFFER_CARDINALITY,
+            UPDATERS_MUST_BE_EOA
+        );
 
         const interfaceIdsFactory = await ethers.getContractFactory("InterfaceIds");
         interfaceIds = await interfaceIdsFactory.deploy();

--- a/test/rates/controllers/truefi/truefi-pid-controller.js
+++ b/test/rates/controllers/truefi/truefi-pid-controller.js
@@ -53,7 +53,7 @@ describe("TrueFiAlocPidController", function () {
             await oracle.deployed();
 
             const controllerFactory = await ethers.getContractFactory("TrueFiAlocPidController");
-            controller = await controllerFactory.deploy(oracle.address, DEFAULT_PERIOD, 1, false);
+            controller = await controllerFactory.deploy(oracle.address, false, DEFAULT_PERIOD, 1, false);
 
             // Grant roles
             const [signer] = await ethers.getSigners();

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,11 @@
     "@chainsafe/persistent-merkle-tree" "^0.4.2"
     case "^1.6.3"
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@ethereum-waffle/chai@4.0.10":
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/@ethereum-waffle/chai/-/chai-4.0.10.tgz#6f600a40b6fdaed331eba42b8625ff23f3a0e59a"
@@ -1808,7 +1813,7 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1894,6 +1899,15 @@ cli-table3@^0.5.0:
     string-width "^2.1.1"
   optionalDependencies:
     colors "^1.1.2"
+
+cli-table3@^0.6.0:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.5.tgz#013b91351762739c16a9567c21a04632e449bf2f"
+  integrity sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -3073,6 +3087,15 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
+
+hardhat-contract-sizer@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/hardhat-contract-sizer/-/hardhat-contract-sizer-2.10.0.tgz#72646f43bfe50e9a5702c9720c9bc3e77d93a2c9"
+  integrity sha512-QiinUgBD5MqJZJh1hl1jc9dNnpJg7eE/w4/4GEnrcmZJJTDbVFNe3+/3Ep24XqISSkYxRz36czcPHKHd/a0dwA==
+  dependencies:
+    chalk "^4.0.0"
+    cli-table3 "^0.6.0"
+    strip-ansi "^6.0.0"
 
 hardhat-gas-reporter@^1.0.9:
   version "1.0.9"


### PR DESCRIPTION
### Prudentia
#### Controllers
- Add flag to enable or disable compute ahead logic: If enabled, the controller's computeRate function will calculate the rate on-the-fly with clamping. Otherwise, it will return the last stored rate.
- Add IonicRateController: A RateController that computes rates for Ionic tokens, accruing interest on the underlying tokens before pushing new rates.